### PR TITLE
Add missing instances and functions from Data.Map

### DIFF
--- a/packages.dhall
+++ b/packages.dhall
@@ -1,5 +1,5 @@
 let upstream =
-      https://raw.githubusercontent.com/purerl/package-sets/erl-0.13.6-20200715/src/packages.dhall sha256:98227ee8945a3c7ca4a105c1001dd067128e504bdd45cb6bd9c4509563d83fb9
+      https://raw.githubusercontent.com/purerl/package-sets/erl-0.14.5-20220204-2/src/packages.dhall sha256:bf284d597ad053b43591b964a52aa0f41ed12a576c3efde85ba999ad65072fc9
 
 let overrides = {=}
 

--- a/src/Erl/Data/Map.erl
+++ b/src/Erl/Data/Map.erl
@@ -18,6 +18,7 @@
         , toUnfoldableUnorderedImpl/2
         , values/1
         , union/2
+        , unionWithImpl/3
 ]).
 
 empty() -> #{}.
@@ -40,6 +41,8 @@ values(M) -> maps:values(M).
 keys(M) -> maps:keys(M).
 
 union(M1, M2) -> maps:merge(M1,M2).
+
+unionWithImpl(F, M1, M2) -> maps:merge_with(fun (_K,A,B) -> F(A,B) end,M1,M2).
 
 mapImpl(F, M) -> maps:map(fun (_K, V) -> F(V) end, M).
 

--- a/src/Erl/Data/Map.erl
+++ b/src/Erl/Data/Map.erl
@@ -1,6 +1,7 @@
 -module(erl_data_map@foreign).
 -export([ delete/2
         , difference/2
+        , intersectionWithImpl/3
         , empty/0
         , filterWithKeyImpl/2
         , foldImpl/3
@@ -62,6 +63,9 @@ difference(M1, M2) ->
             end,
             M1,
             M2).
+
+intersectionWithImpl(F, M1, M2) ->
+  maps:intersect_with(fun(_K,A,B) -> F(A,B) end, M1, M2).
 
 toUnfoldableImpl(Tuple, M) ->
   [Tuple(K, V) || {K, V} <- lists:sort(maps:to_list(M))].

--- a/src/Erl/Data/Map.purs
+++ b/src/Erl/Data/Map.purs
@@ -4,6 +4,8 @@ module Erl.Data.Map
   , alterM
   , delete
   , difference
+  , intersection
+  , intersectionWith
   , empty
   , filter
   , filterKeys
@@ -99,6 +101,12 @@ mapMaybeWithKey f = fold (\acc k a -> maybe acc (\b -> insert k b acc) (f k a)) 
 foreign import member :: forall k a. k -> Map k a -> Boolean
 
 foreign import difference :: forall k a b. Map k a -> Map k b -> Map k a
+
+foreign import intersectionWithImpl :: forall k a b c. (Fn2 a b c) -> Map k a -> Map k b -> Map k c
+
+intersectionWith :: forall k a b c. (a -> b -> c) -> Map k a -> Map k b -> Map k c
+intersectionWith f m1 m2 =
+  intersectionWithImpl (mkFn2 f) m1 m2
 
 foreign import delete :: forall k a. k -> Map k a -> Map k a
 
@@ -221,3 +229,8 @@ filterKeys predicate = filterWithKey $ const <<< predicate
 -- | on the value fails to hold.
 filter :: forall k v. (v -> Boolean) -> Map k v -> Map k v
 filter predicate = filterWithKey $ const predicate
+
+-- | Compute the intersection of two maps, preferring values from the first map in the case
+-- | of duplicate keys.
+intersection :: forall k a b. Map k a -> Map k b -> Map k a
+intersection = intersectionWith const

--- a/src/Erl/Data/Map.purs
+++ b/src/Erl/Data/Map.purs
@@ -31,6 +31,7 @@ module Erl.Data.Map
   , update
   , updateM
   , union
+  , unions
   , unionWith
   ) where
 
@@ -126,6 +127,10 @@ foreign import unionWithImpl :: forall k v. (Fn2 v v v) -> Map k v -> Map k v ->
 unionWith :: forall k v. (v -> v -> v) -> Map k v -> Map k v -> Map k v
 unionWith f m1 m2 =
   unionWithImpl (mkFn2 f) m1 m2
+
+-- | Compute the union of a collection of maps. Keeps the last value for conflicting keys.
+unions :: forall k v f. Foldable f => f (Map k v) -> Map k v
+unions = foldl union empty
 
 -- | Insert the value, delete a value, or update a value for a key in a map
 alter :: forall k v. (Maybe v -> Maybe v) -> k -> Map k v -> Map k v

--- a/src/Erl/Data/Map.purs
+++ b/src/Erl/Data/Map.purs
@@ -5,8 +5,6 @@ module Erl.Data.Map
   , catMaybes
   , delete
   , difference
-  , intersection
-  , intersectionWith
   , empty
   , filter
   , filterKeys
@@ -17,23 +15,25 @@ module Erl.Data.Map
   , fromFoldableWithIndex
   , insert
   , insertWith
+  , intersection
+  , intersectionWith
   , isEmpty
   , keys
   , lookup
-  , mapWithKey
   , mapMaybe
   , mapMaybeWithKey
+  , mapWithKey
   , member
   , singleton
   , size
   , toUnfoldable
   , toUnfoldableUnordered
-  , values
+  , union
+  , unionWith
+  , unions
   , update
   , updateM
-  , union
-  , unions
-  , unionWith
+  , values
   ) where
 
 import Prelude

--- a/src/Erl/Data/Map.purs
+++ b/src/Erl/Data/Map.purs
@@ -2,6 +2,7 @@ module Erl.Data.Map
   ( Map
   , alter
   , alterM
+  , catMaybes
   , delete
   , difference
   , intersection
@@ -101,6 +102,11 @@ mapMaybe = mapMaybeWithKey <<< const
 -- | where the function returns Nothing.
 mapMaybeWithKey :: forall k a b. (k -> a -> Maybe b) -> Map k a -> Map k b
 mapMaybeWithKey f = fold (\acc k a -> maybe acc (\b -> insert k b acc) (f k a)) empty
+
+-- | Filter a map of optional values, keeping only the key/value pairs which
+-- | contain a value, creating a new map.
+catMaybes :: forall k v. Map k (Maybe v) -> Map k v
+catMaybes = mapMaybe identity
 
 foreign import member :: forall k a. k -> Map k a -> Boolean
 

--- a/src/Erl/Data/Map.purs
+++ b/src/Erl/Data/Map.purs
@@ -35,6 +35,8 @@ module Erl.Data.Map
 
 import Prelude
 
+import Control.Alt (class Alt)
+import Control.Plus (class Plus)
 import Data.Eq (class Eq1)
 import Data.Foldable (class Foldable, foldl, foldr)
 import Data.FoldableWithIndex (class FoldableWithIndex, foldlWithIndex)
@@ -219,6 +221,19 @@ instance showMap :: (Show k, Show v) => Show (Map k v) where
     where
       toList :: forall k' v'. Map k' v' -> List (Tuple k' v')
       toList = toUnfoldable
+
+instance altMap :: Alt (Map k) where
+  alt = union
+
+instance plusMap :: Plus (Map k) where
+  empty = empty
+
+instance applyMap :: Apply (Map k) where
+  apply = intersectionWith identity
+
+instance bindMap :: Bind (Map k) where
+  bind m f = mapMaybeWithKey (\k -> lookup k <<< f) m
+
 
 -- | Filter out those key/value pairs of a map for which a predicate
 -- | on the key fails to hold.

--- a/src/Erl/Data/Map.purs
+++ b/src/Erl/Data/Map.purs
@@ -31,6 +31,7 @@ module Erl.Data.Map
   , update
   , updateM
   , union
+  , unionWith
   ) where
 
 import Prelude
@@ -117,6 +118,14 @@ foreign import values :: forall a b. Map a b -> List b
 foreign import keys :: forall a b. Map a b -> List a
 
 foreign import union :: forall k v. Map k v -> Map k v -> Map k v
+
+foreign import unionWithImpl :: forall k v. (Fn2 v v v) -> Map k v -> Map k v -> Map k v
+
+-- | Compute the union of two maps, using the specified function
+-- | to combine values for duplicate keys.
+unionWith :: forall k v. (v -> v -> v) -> Map k v -> Map k v -> Map k v
+unionWith f m1 m2 =
+  unionWithImpl (mkFn2 f) m1 m2
 
 -- | Insert the value, delete a value, or update a value for a key in a map
 alter :: forall k v. (Maybe v -> Maybe v) -> k -> Map k v -> Map k v

--- a/test.dhall
+++ b/test.dhall
@@ -4,5 +4,5 @@ in    conf
     ⫽ { sources =
           conf.sources # [ "test/**/*.purs" ]
       , dependencies =
-          conf.dependencies # [ "assert", "console", "erl-test-eunit" ]
+          conf.dependencies # [ "assert", "erl-test-eunit", "arrays", "control", "effect", "foldable-traversable", "maybe"]
       }

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -140,6 +140,13 @@ main =
                     , expected: (M.lookup 1 m1 <|> M.lookup 1 m2)
                     }
 
+      test "UnionWith uses merge function" do
+        let m1 = M.fromFoldable [Tuple 0 0, Tuple 1 1, Tuple 2 2]
+            m2 = M.fromFoldable [Tuple 1 11, Tuple 2 12, Tuple 4 14]
+        assertEqual { actual: M.unionWith (\a b -> a * 100 + b) m1 m2
+                    , expected: M.fromFoldable [Tuple 0 0, Tuple 1 111, Tuple 2 212, Tuple 4 14]
+                    }
+
       -- alt is just union
       test "Alt is idempotent" do
         let m1 = M.fromFoldable [Tuple 0 0, Tuple 1 1, Tuple 2 2]

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -143,8 +143,8 @@ main =
         let m1 = M.fromFoldable [Tuple 0 0, Tuple 1 1, Tuple 2 2]
             m2 = M.fromFoldable [Tuple 3 3, Tuple 1 1, Tuple 5 5]
             d  = M.difference m1 m2
-        assert (and (map (\k -> M.member 1 m1) (A.fromFoldable $ M.keys d)) &&
-                and (map (\k -> not $ M.member 1 d) (A.fromFoldable $ M.keys m2)))
+        assert (and (map (\_ -> M.member 1 m1) (A.fromFoldable $ M.keys d)) &&
+                and (map (\_ -> not $ M.member 1 d) (A.fromFoldable $ M.keys m2)))
 
       test "size" do
         let xs = nubBy ((==) `on` fst) ((Tuple 1 41) : (Tuple 2 42) : nil)
@@ -161,7 +161,7 @@ main =
       test "filterKeys keeps those keys for which predicate is true" do
         let m1 = M.fromFoldable [Tuple 0 0, Tuple 1 1, Tuple 2 2]
         assert (A.all
-                 ((>) 2) (M.keys (M.filterKeys ((>) 2) m1))
+                 ((>) 2) (A.fromFoldable (M.keys (M.filterKeys ((>) 2) m1)))
                )
 
       test "Member" do

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -147,6 +147,23 @@ main =
                     , expected: M.fromFoldable [Tuple 0 0, Tuple 1 111, Tuple 2 212, Tuple 4 14]
                     }
 
+      test "Unions prefers first" do
+        let m1 = M.fromFoldable [Tuple 1 1, Tuple 5 1]
+            m2 = M.fromFoldable [Tuple 2 2, Tuple 5 2]
+            m3 = M.fromFoldable [Tuple 3 3, Tuple 5 3]
+        assertEqual { actual: M.unions [m1, m2, m3]
+                    , expected: M.fromFoldable [Tuple 1 1, Tuple 2 2, Tuple 3 3, Tuple 5 3]
+                    }
+        assertEqual { actual: M.unions [m3, m2, m1]
+                    , expected: M.fromFoldable [Tuple 1 1, Tuple 2 2, Tuple 3 3, Tuple 5 1]
+                    }
+        assertEqual { actual: M.unions [m3, m1, m2]
+                    , expected: M.fromFoldable [Tuple 1 1, Tuple 2 2, Tuple 3 3, Tuple 5 2]
+                    }
+        assertEqual { actual: M.unions [m1, m2]
+                    , expected: M.fromFoldable [Tuple 1 1, Tuple 2 2, Tuple 5 2]
+                    }
+
       -- alt is just union
       test "Alt is idempotent" do
         let m1 = M.fromFoldable [Tuple 0 0, Tuple 1 1, Tuple 2 2]

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -143,8 +143,23 @@ main =
         let m1 = M.fromFoldable [Tuple 0 0, Tuple 1 1, Tuple 2 2]
             m2 = M.fromFoldable [Tuple 3 3, Tuple 1 1, Tuple 5 5]
             d  = M.difference m1 m2
+
         assert (and (map (\_ -> M.member 1 m1) (A.fromFoldable $ M.keys d)) &&
                 and (map (\_ -> not $ M.member 1 d) (A.fromFoldable $ M.keys m2)))
+
+      test "intersection" do
+        let m1 = M.fromFoldable [Tuple 0 0, Tuple 1 1, Tuple 2 2]
+            m2 = M.fromFoldable [Tuple 3 "c", Tuple 1 "a", Tuple 5 "e"]
+        assertEqual { actual: M.intersection m1 m2
+                    , expected: M.fromFoldable [Tuple 1 1]
+                    }
+
+      test "intersectionWith" do
+        let m1 = M.fromFoldable [Tuple 0 0, Tuple 1 1, Tuple 2 2]
+            m2 = M.fromFoldable [Tuple 3 30, Tuple 1 10, Tuple 5 50]
+        assertEqual { actual: M.intersectionWith (+) m1 m2
+                    , expected: M.fromFoldable [Tuple 1 11]
+                    }
 
       test "size" do
         let xs = nubBy ((==) `on` fst) ((Tuple 1 41) : (Tuple 2 42) : nil)


### PR DESCRIPTION
Added most but not all things that were in Data.Map but not in Erl.Data.Map. Submaps and the near-miss functions like lookupLT are still missing.